### PR TITLE
Display the chat UUID instead of id in the url (#581)

### DIFF
--- a/captn/captn_agents/backend/teams/_daily_analysis_team.py
+++ b/captn/captn_agents/backend/teams/_daily_analysis_team.py
@@ -857,13 +857,13 @@ def _get_function_map(user_id: int, conv_id: int, work_dir: str) -> Dict[str, An
 
 
 def _create_final_html_message(
-    main_email_template: str, proposed_user_action: List[str], conv_id: int
+    main_email_template: str, proposed_user_action: List[str], conv_uuid: str
 ) -> str:
     proposed_user_actions_section = ""
     proposed_action_template = PROPOSED_ACTION_TEMPLATE
 
     for i, action in enumerate(proposed_user_action):
-        proposed_user_actions_section += f"<li>{action} (<a href='{REDIRECT_DOMAIN}/chat/{conv_id}?selected_user_action={i+1}'>Link</a>)</li>"
+        proposed_user_actions_section += f"<li>{action} (<a href='{REDIRECT_DOMAIN}/chat/{conv_uuid}?selected_user_action={i+1}'>Link</a>)</li>"
 
     proposed_action_template = proposed_action_template.replace(
         "{proposed_actions_li_tags}", proposed_user_actions_section
@@ -878,6 +878,7 @@ def _create_final_html_message(
 def _update_chat_message_and_send_email(
     user_id: int,
     conv_id: int,
+    conv_uuid: str,
     client_email: str,
     messages: str,
     initial_message_in_chat: str,
@@ -906,7 +907,7 @@ def _update_chat_message_and_send_email(
         raise ValueError(response.content)
 
     main_email_template = _create_final_html_message(
-        main_email_template, proposed_user_action, conv_id
+        main_email_template, proposed_user_action, conv_uuid
     )
 
     send_email_infobip(
@@ -960,7 +961,7 @@ DO NOT PRCEED WITH GOOGLE ADS ANALYSIS EXCEPT IF THE CLIENT ASKS YOU TO DO SO.]"
     )
 
 
-def _get_conv_id(user_id: int, email: str) -> int:
+def _get_conv_id_and_uuid(user_id: int, email: str) -> Tuple[int, str]:
     data = {"userId": user_id}
 
     response = requests.post(
@@ -970,7 +971,8 @@ def _get_conv_id(user_id: int, email: str) -> int:
         ValueError(f"Wasn't able to create chat for user_id: {user_id} - email {email}")
 
     conv_id = response.json()["chatId"]
-    return conv_id  # type: ignore
+    conv_uuid = response.json()["chatUUID"]
+    return conv_id, conv_uuid  # type: ignore
 
 
 def _delete_chat_webhook(user_id: int, conv_id: int) -> None:
@@ -1005,7 +1007,7 @@ def execute_daily_analysis(
 
             try:
                 daily_analysis_team = None
-                conv_id = _get_conv_id(user_id=user_id, email=email)
+                conv_id, conv_uuid = _get_conv_id_and_uuid(user_id=user_id, email=email)
                 login_url_response = get_login_url(
                     user_id=user_id, conv_id=conv_id
                 ).get("login_url")
@@ -1079,6 +1081,7 @@ Please propose the next steps and send the email to the client.
                     _update_chat_message_and_send_email(
                         user_id=user_id,
                         conv_id=conv_id,
+                        conv_uuid=conv_uuid,
                         client_email=email,
                         messages=messages,
                         initial_message_in_chat=daily_report_message,

--- a/google_ads/application.py
+++ b/google_ads/application.py
@@ -78,7 +78,9 @@ async def get_user(user_id: Union[int, str]) -> Any:
 #     return user_id, chat_id
 
 
-async def get_user_id_from_chat(chat_id: Union[int, str]) -> Any:
+async def get_user_id_chat_uuid_from_chat_id(
+    chat_id: Union[int, str]
+) -> Tuple[int, str]:
     wasp_db_url = await get_wasp_db_url()
     async with get_db_connection(db_url=wasp_db_url) as db:  # type: ignore[var-annotated]
         chat = await db.query_first(
@@ -87,7 +89,8 @@ async def get_user_id_from_chat(chat_id: Union[int, str]) -> Any:
         if not chat:
             raise HTTPException(status_code=404, detail=f"chat {chat} not found")
     user_id = chat["userId"]
-    return user_id
+    chat_uuid = chat["uuid"]
+    return user_id, chat_uuid
 
 
 async def is_authenticated_for_ads(user_id: int) -> bool:
@@ -130,7 +133,7 @@ async def login_callback(
     code: str = Query(title="Authorization Code"), state: str = Query(title="State")
 ) -> RedirectResponse:
     chat_id = state
-    user_id = await get_user_id_from_chat(chat_id)
+    user_id, chat_uuid = await get_user_id_chat_uuid_from_chat_id(chat_id)
     # user_id, chat_id = await get_user_id_chat_id_from_conversation(conv_id)
     user = await get_user(user_id=user_id)
 
@@ -179,7 +182,7 @@ async def login_callback(
     redirect_domain = environ.get("REDIRECT_DOMAIN", "https://captn.ai")
     logged_in_message = "I have successfully logged in"
     # redirect_uri = f"{redirect_domain}/chat/{chat_id}?msg={logged_in_message}&team_id={task.team_id}&team_name={task.team_name}"
-    redirect_uri = f"{redirect_domain}/chat/{chat_id}?msg={logged_in_message}"
+    redirect_uri = f"{redirect_domain}/chat/{chat_uuid}?msg={logged_in_message}"
     return RedirectResponse(redirect_uri)
 
 

--- a/tests/ci/test_daily_analysis_team.py
+++ b/tests/ci/test_daily_analysis_team.py
@@ -1238,6 +1238,7 @@ def test_send_email() -> None:
             _update_chat_message_and_send_email(
                 user_id=1,
                 conv_id=239,
+                conv_uuid="f0d2e864-9fe2-4fa0-b9a7-e8381ed14ef9",
                 client_email="myemail@mail.com",
                 messages="[{'content': 'test'}{content: 'test2'}]",
                 initial_message_in_chat="test",
@@ -1268,8 +1269,8 @@ def test_execute_daily_analysis_with_incorrect_emails() -> None:
         "captn.captn_agents.backend.teams._daily_analysis_team.get_user_ids_and_emails"
     ) as mock_get_user_ids_and_emails:
         with unittest.mock.patch(
-            "captn.captn_agents.backend.teams._daily_analysis_team._get_conv_id"
-        ) as mock_get_conv_id:
+            "captn.captn_agents.backend.teams._daily_analysis_team._get_conv_id_and_uuid"
+        ) as mock_get_conv_id_and_uuid:
             mock_get_user_ids_and_emails.return_value = json.dumps(
                 {
                     1: "name@mail.com",
@@ -1280,7 +1281,7 @@ def test_execute_daily_analysis_with_incorrect_emails() -> None:
             execute_daily_analysis(
                 send_only_to_emails=["bla1@mail.com", "bla2@mail.com"]
             )
-            mock_get_conv_id.assert_not_called()
+            mock_get_conv_id_and_uuid.assert_not_called()
 
 
 def test_google_ads_api_call_reties_three_times() -> None:
@@ -1323,8 +1324,8 @@ def test_execute_daily_analysis_workflow() -> None:
     ) as mock_get_user_ids_and_emails:
 
         with unittest.mock.patch(
-            "captn.captn_agents.backend.teams._daily_analysis_team._get_conv_id"
-        ) as mock_get_conv_id:
+            "captn.captn_agents.backend.teams._daily_analysis_team._get_conv_id_and_uuid"
+        ) as mock_get_conv_id_and_uuid:
 
             with unittest.mock.patch(
                 "captn.captn_agents.backend.teams._daily_analysis_team.get_login_url"
@@ -1348,7 +1349,10 @@ def test_execute_daily_analysis_workflow() -> None:
                                 mock_get_user_ids_and_emails.return_value = (
                                     """{"1": "robert@airt.ai"}"""
                                 )
-                                mock_get_conv_id.return_value = -1
+                                mock_get_conv_id_and_uuid.return_value = (
+                                    -1,
+                                    "f0d2e864-9fe2-4fa0-b9a7-e8381ed14ef9",
+                                )
                                 mock_get_login_url.return_value = {
                                     "login_url": ALREADY_AUTHENTICATED
                                 }


### PR DESCRIPTION
* Use chat uuid instead of id in daily analysis and auth redirection URL

* Polishing